### PR TITLE
Fix: Align --observables argument behavior with its documentation

### DIFF
--- a/src/muller_brown/config.py
+++ b/src/muller_brown/config.py
@@ -10,7 +10,7 @@ from src.muller_brown.constants import (
 from src.muller_brown.io import _validate_positive_integer
 
 # Default observables to save and plot
-DEFAULT_OBSERVABLES = ["positions"]
+DEFAULT_OBSERVABLES = ["positions", "velocities", "forces", "potential_energy"]
 AVAILABLE_OBSERVABLES = ["positions", "velocities", "forces", "potential_energy"]
 
 


### PR DESCRIPTION
In the `main` file, the following code snippet is present. In reality, only the `positions` data is saved.

```python
parser.add_argument(
    "--observables",
    nargs="*",
    default=None,
    help="List of observables to save and plot. Available options: positions, velocities, forces, potential_energy. Default: all observables",
)
```