### PR TITLE
Certify the artifact: presentation trims + installable packaging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ PyTorch implementation of the Müller-Brown 2D potential energy surface with Lan
 This project uses `uv`. Run everything through it.
 
 ```bash
-uv sync                                          # install dependencies
+uv sync                                          # install dependencies + the package (editable)
 uv run python main.py --mode demo                # show potential info (minima, saddles, sample energies/forces)
 uv run python main.py --mode single --save-plots # one simulation -> new artifacts/<timestamp>/ dir
 uv run python main.py --mode batch --n-simulations 10 --save-plots
@@ -46,7 +46,7 @@ Things that take reading multiple files to see:
 - **`config.py`** produces the nested `simulation`/`initial_conditions`/`output` dict consumed everywhere; `create_experiment_config()` is the single source of defaults.
 
 ## Conventions
-- **Imports are absolute from the repo root** (`from src.muller_brown...`), so run all scripts from the project root, not from inside `src/`.
+- **Imports are package-absolute** (`from muller_brown import ...`); `uv sync` installs the package editable (src-layout, `src/muller_brown/`), so it resolves the same from scripts, tests, or a REPL. Run scripts from the project root so relative artifact paths (`artifacts/`) resolve.
 - **Default dtype is `torch.float64`, device CPU** (`constants.py`). Keep simulation code in double precision; scientific correctness and reproducibility come first.
 - Canonical potential parameters and critical-point locations live in `constants.py` / `potential.py` — reuse them, don't re-hardcode.
 - Type hints: builtin generics and `|` only — `list`/`dict`/`tuple`/`set`, `X | None` (not `Optional`), `A | B` (not `Union`). `_` prefix for private members, `ALL_CAPS` for constants.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 [![PyTorch](https://img.shields.io/badge/PyTorch-2.0%2B-orange.svg)](https://pytorch.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
-A modern, efficient PyTorch implementation of the Müller-Brown potential energy surface with Langevin dynamics simulation.
+A PyTorch implementation of the Müller-Brown potential energy surface with BAOAB Langevin dynamics.
 
 ## Overview
 
-This package provides a clean implementation of the Müller-Brown potential, a 2D model potential energy surface widely used for testing molecular dynamics algorithms and studying rare events in chemical systems.
+This package implements the Müller-Brown potential, a 2D model potential energy surface widely used for testing molecular dynamics algorithms and studying rare events in chemical systems.
 
 See [Implementing the Müller-Brown Potential in PyTorch](https://hunterheidenreich.com/posts/muller-brown-in-pytorch/) for a detailed blog post explaining the implementation and usage.
 
@@ -70,7 +70,7 @@ uv run python main.py --mode plot --artifact-dir artifacts/20250824_184610
 
 ```python
 import torch
-from src.muller_brown import MuellerBrownPotential, LangevinSimulator, MuellerBrownVisualizer
+from muller_brown import MuellerBrownPotential, LangevinSimulator, MuellerBrownVisualizer
 
 # Create the potential
 potential = MuellerBrownPotential(dtype=torch.float64)
@@ -156,7 +156,7 @@ muller_brown/
 ├── src/muller_brown/        # Core package
 │   ├── potential.py         # Müller-Brown potential (torch.compile force)
 │   ├── simulation.py        # Langevin dynamics simulator
-│   ├── visualization.py     # Comprehensive plotting suite
+│   ├── visualization.py     # Plotting and animation suite
 │   ├── io.py               # HDF5 data I/O operations
 │   ├── data.py             # Data processing utilities
 │   ├── analysis.py         # Statistical analysis functions
@@ -190,20 +190,20 @@ muller_brown/
 
 ### `MuellerBrownVisualizer`
 
-- Comprehensive suite of distribution plots
-- Time-series analysis for all observables
+- Distribution plots for every observable (position, velocity, force, energy)
+- Time-series plots for all observables
 - Log-scale visualization for rare events
 - Automatic critical point annotation
 
 ## Performance
 
-The implementation is optimized for:
+Design choices that affect performance:
 
-- **Compiled forces**: `torch.compile` (shape-dynamic) for fast force evaluation
-- **GPU Support**: All tensors support CUDA acceleration
-- **Efficient Storage**: HDF5 with compression for large datasets
-- **Numerical Stability**: Double precision by default
-- **Memory Management**: Configurable save frequency for long simulations
+- **Compiled forces**: `torch.compile` (shape-dynamic) on the force path
+- **Device-agnostic**: runs on CPU or CUDA; the included benchmark measures CPU
+- **Storage**: HDF5 with gzip compression for large trajectories
+- **Numerical precision**: double precision (`float64`) by default
+- **Memory**: configurable save frequency for long simulations
 
 Each step is vectorized over particles, so for small particle counts the wall
 time is dominated by fixed per-step overhead (the force call and noise draw): a

--- a/benchmark.py
+++ b/benchmark.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 from pathlib import Path
 import json
 from dataclasses import dataclass, asdict
-from src.muller_brown import MuellerBrownPotential
+from muller_brown import MuellerBrownPotential
 
 
 @dataclass

--- a/convergence_study.py
+++ b/convergence_study.py
@@ -17,7 +17,7 @@ import torch
 import torch.nn as nn
 import matplotlib.pyplot as plt
 
-from src.muller_brown import MuellerBrownPotential, LangevinSimulator, set_random_seed
+from muller_brown import MuellerBrownPotential, LangevinSimulator, set_random_seed
 
 
 class StiffHarmonic(nn.Module):

--- a/example.py
+++ b/example.py
@@ -8,7 +8,7 @@ and creating visualizations programmatically.
 
 import torch
 
-from src.muller_brown import (
+from muller_brown import (
     MuellerBrownPotential,
     LangevinSimulator,
     MuellerBrownVisualizer,

--- a/main.py
+++ b/main.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
-Modern implementation of Müller-Brown potential simulation.
+Command-line interface for Müller-Brown potential simulation.
 
-This script demonstrates the usage of the modular Müller-Brown simulation package
-with clean separation of concerns and modern PyTorch practices.
+Entry point over the simulation package: demo, single-run, batch, and
+plot-regeneration modes wiring the potential, integrator, and visualizer.
 """
 
 import argparse
@@ -12,7 +12,7 @@ from pathlib import Path
 import matplotlib.pyplot as plt
 import torch
 
-from src.muller_brown import (
+from muller_brown import (
     MuellerBrownPotential,
     LangevinSimulator,
     MuellerBrownVisualizer,
@@ -83,7 +83,7 @@ def run_batch_simulation(n_simulations: int = 10, observables: list[str] | None 
     base_seed = sim_kwargs["seed"]  # Now always has a value
 
     # Create a main artifact directory for this batch
-    from src.muller_brown import create_artifact_directory
+    from muller_brown import create_artifact_directory
 
     batch_artifact_dir = create_artifact_directory()
     print(f"Saving batch results to: {batch_artifact_dir}")

--- a/nnp.py
+++ b/nnp.py
@@ -4,7 +4,7 @@ import torch.optim as optim
 import numpy as np
 import matplotlib.pyplot as plt
 
-from src.muller_brown import MuellerBrownPotential
+from muller_brown import MuellerBrownPotential
 
 # --- 1. The Student Model (Simple MLP) ---
 class SimpleNNP(nn.Module):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "muller-brown"
 version = "0.1.0"
-description = "Modern PyTorch implementation of the Müller-Brown potential energy surface with Langevin dynamics simulation"
+description = "PyTorch implementation of the Müller-Brown potential energy surface with BAOAB Langevin dynamics"
 readme = "README.md"
 requires-python = ">=3.10"
 license = {text = "MIT"}
@@ -36,7 +36,6 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-pythonpath = ["."]
 markers = [
     "statistical: seeded stochastic tests with tolerance-based assertions (slower)",
 ]
@@ -44,3 +43,10 @@ filterwarnings = [
     # torch.compile's mkldnn path emits this from torch internals, not our code
     "ignore:.*torch.jit.script_method.*:DeprecationWarning",
 ]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/muller_brown"]

--- a/src/muller_brown/__init__.py
+++ b/src/muller_brown/__init__.py
@@ -1,4 +1,4 @@
-"""Modern PyTorch implementation of the Müller-Brown potential."""
+"""PyTorch implementation of the Müller-Brown potential."""
 
 from .analysis import calculate_trajectory_statistics
 from .config import generate_initial_positions, create_experiment_config, validate_observables, DEFAULT_OBSERVABLES, AVAILABLE_OBSERVABLES

--- a/src/muller_brown/analysis.py
+++ b/src/muller_brown/analysis.py
@@ -4,7 +4,7 @@ import numpy as np
 
 
 def calculate_trajectory_statistics(data: dict) -> dict:
-    """Calculate comprehensive statistical properties from simulation data."""
+    """Calculate summary statistics (means, stds, extrema) from simulation data."""
     if "positions" not in data:
         raise ValueError("Positions data is required for trajectory statistics")
     

--- a/src/muller_brown/config.py
+++ b/src/muller_brown/config.py
@@ -2,12 +2,12 @@
 
 import numpy as np
 
-from src.muller_brown.constants import (
+from muller_brown.constants import (
     MULLER_BROWN_MINIMA,
     DEFAULT_X_RANGE,
     DEFAULT_Y_RANGE,
 )
-from src.muller_brown.io import _validate_positive_integer
+from muller_brown.io import _validate_positive_integer
 
 # Default observables to save and plot
 DEFAULT_OBSERVABLES = ["positions", "velocities", "forces", "potential_energy"]

--- a/src/muller_brown/data.py
+++ b/src/muller_brown/data.py
@@ -4,7 +4,7 @@ import random
 import numpy as np
 import torch
 
-from src.muller_brown.constants import DEFAULT_DEVICE, DEFAULT_DTYPE
+from muller_brown.constants import DEFAULT_DEVICE, DEFAULT_DTYPE
 
 
 def set_random_seed(seed: int) -> None:

--- a/src/muller_brown/io.py
+++ b/src/muller_brown/io.py
@@ -26,7 +26,7 @@ def _save_hdf5_file(data: dict, filepath: Path, observables: list[str] | None = 
     """
     # Default to all observables if none specified
     if observables is None:
-        from src.muller_brown.config import DEFAULT_OBSERVABLES
+        from muller_brown.config import DEFAULT_OBSERVABLES
         observables = DEFAULT_OBSERVABLES
     
     with h5py.File(filepath, "w") as f:

--- a/src/muller_brown/potential.py
+++ b/src/muller_brown/potential.py
@@ -71,7 +71,7 @@ def _calculate_force(
 
 class MuellerBrownPotential(nn.Module):
     """
-    Müller-Brown potential energy surface with JIT-compiled force calculations.
+    Müller-Brown potential energy surface with torch.compile-accelerated forces.
 
     V(x,y) = ∑ᵢ Aᵢ exp(aᵢ(x-x₀ᵢ)² + bᵢ(x-x₀ᵢ)(y-y₀ᵢ) + cᵢ(y-y₀ᵢ)²)
     """

--- a/src/muller_brown/simulation.py
+++ b/src/muller_brown/simulation.py
@@ -7,9 +7,9 @@ import torch
 from torch import Tensor
 from tqdm import tqdm
 
-from src.muller_brown.potential import MuellerBrownPotential
-from src.muller_brown.data import convert_to_tensor
-from src.muller_brown.constants import DEFAULT_DEVICE, DEFAULT_DTYPE
+from muller_brown.potential import MuellerBrownPotential
+from muller_brown.data import convert_to_tensor
+from muller_brown.constants import DEFAULT_DEVICE, DEFAULT_DTYPE
 
 
 class LangevinSimulator:

--- a/src/muller_brown/visualization.py
+++ b/src/muller_brown/visualization.py
@@ -1,4 +1,4 @@
-"""Modern visualization tools for the Müller-Brown potential and simulation data."""
+"""Visualization tools for the Müller-Brown potential and simulation data."""
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -7,8 +7,8 @@ from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 from pathlib import Path
 
-from src.muller_brown.potential import MuellerBrownPotential
-from src.muller_brown.data import convert_to_tensor
+from muller_brown.potential import MuellerBrownPotential
+from muller_brown.data import convert_to_tensor
 
 
 # Default plotting constants (wider than the simulation ranges in constants.py,
@@ -23,7 +23,7 @@ DEFAULT_LEVELS = 24
 
 
 class MuellerBrownVisualizer:
-    """Modern visualization tools for Müller-Brown potential and simulation observables."""
+    """Visualization tools for the Müller-Brown potential and simulation observables."""
 
     def __init__(self, potential: MuellerBrownPotential):
         """Initialize the visualizer."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,6 @@
 """The public API stays consistent: everything in __all__ is importable."""
 
-import src.muller_brown as mb
+import muller_brown as mb
 
 
 def test_all_exports_are_importable():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,14 +4,14 @@ and experiment-config construction (including its input validation)."""
 import numpy as np
 import pytest
 
-from src.muller_brown import (
+from muller_brown import (
     generate_initial_positions,
     validate_observables,
     create_experiment_config,
     DEFAULT_OBSERVABLES,
     set_random_seed,
 )
-from src.muller_brown.constants import MULLER_BROWN_MINIMA
+from muller_brown.constants import MULLER_BROWN_MINIMA
 
 
 def test_random_positions_have_right_shape():

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -4,8 +4,8 @@ conversion."""
 import numpy as np
 import torch
 
-from src.muller_brown import apply_transient_removal, combine_batch_trajectories
-from src.muller_brown.data import convert_to_tensor
+from muller_brown import apply_transient_removal, combine_batch_trajectories
+from muller_brown.data import convert_to_tensor
 
 
 def _fake_results(n_saved: int = 10, n_particles: int = 2, save_every: int = 100) -> dict:

--- a/tests/test_integrator.py
+++ b/tests/test_integrator.py
@@ -10,7 +10,7 @@ than a sampling one.
 import numpy as np
 import torch
 
-from src.muller_brown import MuellerBrownPotential, LangevinSimulator, set_random_seed
+from muller_brown import MuellerBrownPotential, LangevinSimulator, set_random_seed
 
 
 def _run(seed: int) -> dict:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -4,7 +4,7 @@ subset chosen at save time."""
 import numpy as np
 import torch
 
-from src.muller_brown import (
+from muller_brown import (
     MuellerBrownPotential,
     LangevinSimulator,
     save_simulation_data,

--- a/tests/test_potential.py
+++ b/tests/test_potential.py
@@ -9,7 +9,7 @@ Newton refinement lands on a true stationary point a tiny distance away.
 import torch
 from torch.autograd.functional import hessian
 
-from src.muller_brown import MuellerBrownPotential
+from muller_brown import MuellerBrownPotential
 
 
 def _hessian_eigenvalues(potential: MuellerBrownPotential, x: torch.Tensor) -> torch.Tensor:

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -15,7 +15,7 @@ import torch
 import torch.nn as nn
 import pytest
 
-from src.muller_brown import MuellerBrownPotential, LangevinSimulator, set_random_seed
+from muller_brown import MuellerBrownPotential, LangevinSimulator, set_random_seed
 
 
 class HarmonicPotential(nn.Module):

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 from matplotlib.figure import Figure
 
-from src.muller_brown import (
+from muller_brown import (
     MuellerBrownPotential,
     LangevinSimulator,
     MuellerBrownVisualizer,

--- a/uv.lock
+++ b/uv.lock
@@ -712,7 +712,7 @@ wheels = [
 [[package]]
 name = "muller-brown"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "h5py" },
     { name = "matplotlib" },

--- a/verify_langevin.py
+++ b/verify_langevin.py
@@ -20,7 +20,7 @@ import torch.nn as nn
 import matplotlib.pyplot as plt
 from torch import Tensor
 
-from src.muller_brown import LangevinSimulator, set_random_seed
+from muller_brown import LangevinSimulator, set_random_seed
 
 
 class HarmonicPotential(nn.Module):


### PR DESCRIPTION
Two coordinated passes to certify the repo as a standalone artifact under a "claim at or below the record" standard. The README was already honest (no ungrounded multipliers, no padding sections, an exemplary dt²-bias "Note on accuracy"); these are altitude trims plus the one packaging refactor that makes the `[project]` metadata real.

## Presentation trims (subtractive, specificity-favoring)
- **One-liner** (README, `pyproject`, and the GitHub description): `"A modern, efficient PyTorch implementation ..."` → `"A PyTorch implementation of the Müller-Brown potential energy surface with BAOAB Langevin dynamics."` BAOAB is the distinctive, credible signal; "modern, efficient" signaled nothing.
- **Docstring house-style**: dropped the `Modern` / `clean` / `comprehensive` openers across the package and `main.py` for specifics.
- **README Performance** — the one real overclaim: `"optimized for ... GPU Support: All tensors support CUDA acceleration"` → `"Design choices that affect performance ... Device-agnostic: runs on CPU or CUDA; the included benchmark measures CPU."` The benchmark and tests are CPU-only, so the old wording implied verified GPU performance.
- `potential.py` docstring `JIT-compiled` → `torch.compile-accelerated` (matches the decorator).
- GitHub topics (already applied): dropped `deep-learning` (the only DL is the standalone `nnp.py` toy), added `scientific-computing` + `langevin-dynamics`.

## Packaging: `import muller_brown`, not `src.muller_brown`
The repo had no `[build-system]` and worked only via pytest's `pythonpath=["."]`, which forced the non-idiomatic `from src.muller_brown ...` everywhere and left the `[project]` metadata non-functional.
- Added a hatchling build-system with src-layout package config, so `uv sync` installs the package editable and `from muller_brown import ...` resolves from scripts, tests, and a REPL.
- Rewrote every import across `src/`, scripts, and tests; updated README / CLAUDE.md. The package stays at `src/muller_brown/`.

## Verification
- Full suite: **61 tests** (deterministic + statistical) pass.
- `ruff check .` clean.
- `uv sync` installs `muller-brown==0.1.0` editable; `import muller_brown` resolves to `src/muller_brown`; `main.py --mode demo` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)